### PR TITLE
画像アップロードを別個に設ける

### DIFF
--- a/src/components/ListingForm.tsx
+++ b/src/components/ListingForm.tsx
@@ -247,7 +247,11 @@ export const ListingForm = ({
       )}
 
       <label className="formLabel">Images</label>
-      <p className="imagesInfo">The first image will be the cover (max 6).</p>
+      <p className="imagesInfo">
+        The first image will be the cover (max 6).
+        <br />
+        Each image must be under 2MB.
+      </p>
 
       <input
         type="file"

--- a/src/components/ListingForm.tsx
+++ b/src/components/ListingForm.tsx
@@ -1,7 +1,6 @@
-import { FormDataType } from "../type";
+import { FormDataType, ListingsItemDataType } from "../type";
 
 type PropsType = {
-  ActionText: string;
   formData: FormDataType;
   onSubmit: (e: React.FormEvent) => void;
   onMutate: (
@@ -9,14 +8,23 @@ type PropsType = {
       React.ChangeEvent<HTMLTextAreaElement> &
       React.MouseEvent<HTMLButtonElement>
   ) => void;
+  handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleUpload: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  handleDeleteImage: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  uploadedImages: ListingsItemDataType["imgUrls"];
+  inputRef: React.RefObject<HTMLInputElement>;
   geolocationEnabled: boolean;
 };
 
 export const ListingForm = ({
-  ActionText,
   formData,
   onSubmit,
   onMutate,
+  handleChange,
+  handleUpload,
+  handleDeleteImage,
+  uploadedImages,
+  inputRef,
   geolocationEnabled,
 }: PropsType) => {
   const {
@@ -35,235 +43,284 @@ export const ListingForm = ({
   } = formData;
 
   return (
-    <div className="profile">
-      <header>
-        <p className="pageHeader">{ActionText} Listing</p>
-      </header>
-      <main>
-        <form onSubmit={onSubmit}>
-          <label className="formLabel">Sell / Rent</label>
-          <div className="formButtons">
-            <button
-              type="button"
-              className={type === "sale" ? "formButtonActive" : "formButton"}
-              id="type"
-              value="sale"
-              onClick={onMutate}
-            >
-              Sell
-            </button>
-            <button
-              type="button"
-              className={type === "rent" ? "formButtonActive" : "formButton"}
-              id="type"
-              value="rent"
-              onClick={onMutate}
-            >
-              Rent
-            </button>
-          </div>
+    <form onSubmit={onSubmit}>
+      <label className="formLabel">Sell / Rent</label>
+      <div className="formButtons">
+        <button
+          type="button"
+          className={type === "sale" ? "formButtonActive" : "formButton"}
+          id="type"
+          value="sale"
+          onClick={onMutate}
+        >
+          Sell
+        </button>
+        <button
+          type="button"
+          className={type === "rent" ? "formButtonActive" : "formButton"}
+          id="type"
+          value="rent"
+          onClick={onMutate}
+        >
+          Rent
+        </button>
+      </div>
 
-          <label className="formLabel">Name</label>
+      <label className="formLabel">Name</label>
+      <input
+        className="formInputName"
+        type="text"
+        id="name"
+        value={name}
+        onChange={onMutate}
+        maxLength={32}
+        minLength={10}
+        required
+      />
+
+      <div className="formRooms flex">
+        <div>
+          <label className="formLabel">Bedrooms</label>
           <input
-            className="formInputName"
-            type="text"
-            id="name"
-            value={name}
+            className="formInputSmall"
+            type="number"
+            id="bedrooms"
+            value={bedrooms}
             onChange={onMutate}
-            maxLength={32}
-            minLength={10}
+            min="1"
+            max="50"
             required
           />
-
-          <div className="formRooms flex">
-            <div>
-              <label className="formLabel">Bedrooms</label>
-              <input
-                className="formInputSmall"
-                type="number"
-                id="bedrooms"
-                value={bedrooms}
-                onChange={onMutate}
-                min="1"
-                max="50"
-                required
-              />
-            </div>
-            <div>
-              <label className="formLabel">Bathrooms</label>
-              <input
-                className="formInputSmall"
-                type="number"
-                id="bathrooms"
-                value={bathrooms}
-                onChange={onMutate}
-                min="1"
-                max="50"
-                required
-              />
-            </div>
-          </div>
-
-          <label className="formLabel">Parking spot</label>
-          <div className="formButtons">
-            <button
-              className={parking ? "formButtonActive" : "formButton"}
-              type="button"
-              id="parking"
-              value="true"
-              onClick={onMutate}
-            >
-              Yes
-            </button>
-            <button
-              className={
-                !parking && parking !== null ? "formButtonActive" : "formButton"
-              }
-              type="button"
-              id="parking"
-              value="false"
-              onClick={onMutate}
-            >
-              No
-            </button>
-          </div>
-
-          <label className="formLabel">Furnished</label>
-          <div className="formButtons">
-            <button
-              className={furnished ? "formButtonActive" : "formButton"}
-              type="button"
-              id="furnished"
-              value="true"
-              onClick={onMutate}
-            >
-              Yes
-            </button>
-            <button
-              className={
-                !furnished && furnished !== null
-                  ? "formButtonActive"
-                  : "formButton"
-              }
-              type="button"
-              id="furnished"
-              value="false"
-              onClick={onMutate}
-            >
-              No
-            </button>
-          </div>
-
-          <label className="formLabel">Address</label>
-          <textarea
-            className="formInputAddress"
-            id="address"
-            value={address}
+        </div>
+        <div>
+          <label className="formLabel">Bathrooms</label>
+          <input
+            className="formInputSmall"
+            type="number"
+            id="bathrooms"
+            value={bathrooms}
             onChange={onMutate}
+            min="1"
+            max="50"
             required
           />
+        </div>
+      </div>
 
-          {!geolocationEnabled && (
-            <div className="formLatLng flex">
-              <div>
-                <label className="formLabel">Latitude</label>
-                <input
-                  className="formInputSmall"
-                  type="number"
-                  id="latitude"
-                  value={latitude}
-                  onChange={onMutate}
-                  required
-                />
-              </div>
-              <div>
-                <label className="formLabel">Longitude</label>
-                <input
-                  className="formInputSmall"
-                  type="number"
-                  id="longitude"
-                  value={longitude}
-                  onChange={onMutate}
-                  required
-                />
-              </div>
-            </div>
-          )}
+      <label className="formLabel">Parking spot</label>
+      <div className="formButtons">
+        <button
+          className={parking ? "formButtonActive" : "formButton"}
+          type="button"
+          id="parking"
+          value="true"
+          onClick={onMutate}
+        >
+          Yes
+        </button>
+        <button
+          className={
+            !parking && parking !== null ? "formButtonActive" : "formButton"
+          }
+          type="button"
+          id="parking"
+          value="false"
+          onClick={onMutate}
+        >
+          No
+        </button>
+      </div>
 
-          <label className="formLabel">Offer</label>
-          <div className="formButtons">
-            <button
-              className={offer ? "formButtonActive" : "formButton"}
-              type="button"
-              id="offer"
-              value="true"
-              onClick={onMutate}
-            >
-              Yes
-            </button>
-            <button
-              className={
-                !offer && offer !== null ? "formButtonActive" : "formButton"
-              }
-              type="button"
-              id="offer"
-              value="false"
-              onClick={onMutate}
-            >
-              No
-            </button>
-          </div>
+      <label className="formLabel">Furnished</label>
+      <div className="formButtons">
+        <button
+          className={furnished ? "formButtonActive" : "formButton"}
+          type="button"
+          id="furnished"
+          value="true"
+          onClick={onMutate}
+        >
+          Yes
+        </button>
+        <button
+          className={
+            !furnished && furnished !== null ? "formButtonActive" : "formButton"
+          }
+          type="button"
+          id="furnished"
+          value="false"
+          onClick={onMutate}
+        >
+          No
+        </button>
+      </div>
 
-          <label className="formLabel">Regular Price</label>
-          <div className="formPriceDiv">
+      <label className="formLabel">Address</label>
+      <textarea
+        className="formInputAddress"
+        id="address"
+        value={address}
+        onChange={onMutate}
+        required
+      />
+
+      {!geolocationEnabled && (
+        <div className="formLatLng flex">
+          <div>
+            <label className="formLabel">Latitude</label>
             <input
               className="formInputSmall"
               type="number"
-              id="regularPrice"
-              value={regularPrice}
+              id="latitude"
+              value={latitude}
               onChange={onMutate}
-              min="50"
-              max="750000000"
               required
             />
-            {type === "rent" && <p className="formPriceText">$ / Month</p>}
           </div>
+          <div>
+            <label className="formLabel">Longitude</label>
+            <input
+              className="formInputSmall"
+              type="number"
+              id="longitude"
+              value={longitude}
+              onChange={onMutate}
+              required
+            />
+          </div>
+        </div>
+      )}
 
-          {offer && (
-            <>
-              <label className="formLabel">Discounted Price</label>
-              <input
-                className="formInputSmall"
-                type="number"
-                id="discountedPrice"
-                value={discountedPrice}
-                onChange={onMutate}
-                min="50"
-                max="750000000"
-                required={offer}
-              />
-            </>
-          )}
+      <label className="formLabel">Offer</label>
+      <div className="formButtons">
+        <button
+          className={offer ? "formButtonActive" : "formButton"}
+          type="button"
+          id="offer"
+          value="true"
+          onClick={onMutate}
+        >
+          Yes
+        </button>
+        <button
+          className={
+            !offer && offer !== null ? "formButtonActive" : "formButton"
+          }
+          type="button"
+          id="offer"
+          value="false"
+          onClick={onMutate}
+        >
+          No
+        </button>
+      </div>
 
-          <label className="formLabel">Images</label>
-          <p className="imagesInfo">
-            The first image will be the cover (max 6).
-          </p>
+      <label className="formLabel">Regular Price</label>
+      <div className="formPriceDiv">
+        <input
+          className="formInputSmall"
+          type="number"
+          id="regularPrice"
+          value={regularPrice}
+          onChange={onMutate}
+          min="50"
+          max="750000000"
+          required
+        />
+        {type === "rent" && <p className="formPriceText">$ / Month</p>}
+      </div>
+
+      {offer && (
+        <>
+          <label className="formLabel">Discounted Price</label>
           <input
-            className="formInputFile"
-            type="file"
-            id="images"
+            className="formInputSmall"
+            type="number"
+            id="discountedPrice"
+            value={discountedPrice}
             onChange={onMutate}
-            max="6"
-            accept=".jpg,.png,.jpeg"
-            multiple
-            required
+            min="50"
+            max="750000000"
+            required={offer}
           />
-          <button type="submit" className="primaryButton createListingButton">
-            {ActionText} Listing
-          </button>
-        </form>
-      </main>
-    </div>
+        </>
+      )}
+
+      <label className="formLabel">Images</label>
+      <p className="imagesInfo">The first image will be the cover (max 6).</p>
+
+      <input
+        type="file"
+        onChange={handleChange}
+        max="6"
+        accept=".jpg,.png,.jpeg"
+        multiple
+        ref={inputRef}
+        hidden
+      />
+      <button
+        type="button"
+        onClick={handleUpload}
+        style={{
+          backgroundColor: "black",
+          color: "white",
+          fontSize: "16px",
+          padding: "10px 60px",
+          borderRadius: "5px",
+          margin: "10px 0px",
+          cursor: "pointer",
+        }}
+      >
+        Upload files
+      </button>
+      {uploadedImages && (
+        <ul
+          style={{
+            listStyle: "none",
+            padding: "0px",
+          }}
+        >
+          {uploadedImages.map((url, index) => (
+            <li
+              key={index}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                marginBottom: "1em",
+              }}
+            >
+              <img
+                src={url}
+                alt=""
+                width="200"
+                height="200"
+                loading="lazy"
+                style={{ objectFit: "cover" }}
+              />
+              <button
+                type="button"
+                onClick={handleDeleteImage}
+                data-url={url}
+                style={{
+                  backgroundColor: "black",
+                  color: "white",
+                  fontSize: "13px",
+                  padding: "10px",
+                  borderRadius: "5px",
+                  margin: "10px",
+                  cursor: "pointer",
+                }}
+              >
+                Delete
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <button type="submit" className="primaryButton createListingButton">
+        Submit Listing
+      </button>
+    </form>
   );
 };

--- a/src/pages/EditListing.tsx
+++ b/src/pages/EditListing.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { getAuth, onAuthStateChanged } from "firebase/auth";
 import { doc, updateDoc, getDoc, serverTimestamp } from "firebase/firestore";
 import { db } from "../firebase.config";
@@ -8,6 +8,7 @@ import { toast } from "react-toastify";
 import { listingsConverter, storeImage } from "../utils";
 import { FormDataType, ListingsItemDataType } from "../type";
 import { ListingForm } from "../components/ListingForm";
+import { deleteObject, getStorage, ref } from "firebase/storage";
 
 const initialFormState: FormDataType = {
   type: "rent",
@@ -25,6 +26,8 @@ const initialFormState: FormDataType = {
   userRef: "",
 };
 
+const storage = getStorage();
+
 export const EditListing = () => {
   // handle geolocation input is not implemented
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -34,14 +37,14 @@ export const EditListing = () => {
 
   const [formData, setFormData] = useState<FormDataType>(initialFormState);
 
-  const {
-    address,
-    regularPrice,
-    discountedPrice,
-    images,
-    latitude,
-    longitude,
-  } = formData;
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const [uploadedImages, setUploadedImages] = useState<
+    ListingsItemDataType["imgUrls"]
+  >([]);
+
+  const { address, regularPrice, discountedPrice, latitude, longitude } =
+    formData;
 
   const auth = getAuth();
   const navigate = useNavigate();
@@ -72,10 +75,10 @@ export const EditListing = () => {
         setFormData({
           ...docSnapshot.data(),
           address: docSnapshot.data().location,
-          images: docSnapshot.data().imgUrls,
           latitude: docSnapshot.data().geolocation.lat,
           longitude: docSnapshot.data().geolocation.lng,
         });
+        setUploadedImages(docSnapshot.data().imgUrls);
         setLoading(false);
       } else {
         navigate("/");
@@ -101,7 +104,8 @@ export const EditListing = () => {
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    if (images === undefined) {
+    if (!uploadedImages.length) {
+      toast.error("Please upload at least one image");
       return;
     }
     if (!params.listingId) {
@@ -116,7 +120,7 @@ export const EditListing = () => {
       return;
     }
 
-    if (images.length > 6) {
+    if (uploadedImages.length > 6) {
       setLoading(false);
       toast.error("Maximum 6 images allowed");
       return;
@@ -145,23 +149,14 @@ export const EditListing = () => {
       }
     }
 
-    const imgUrls = await Promise.all(
-      Array.from(images).map((image) => storeImage(image))
-    ).catch(() => {
-      setLoading(false);
-      toast.error("Error uploading images");
-      return;
-    });
-
     const formDataCopy = {
       ...formData,
-      imgUrls,
+      imgUrls: uploadedImages,
       geolocation: _geolocation,
       timestamp: serverTimestamp(),
     };
 
     formDataCopy.location = address;
-    delete formDataCopy.images;
     delete formDataCopy.address;
     !formDataCopy.offer && delete formDataCopy.discountedPrice;
 
@@ -187,21 +182,60 @@ export const EditListing = () => {
       toggleFlag = false;
     }
 
-    // Files
-    if (e.target.files) {
-      setFormData((prevState) => ({
-        ...prevState,
-        images: e.target.files as FileList,
-      }));
-    }
-
     // Text, Boolean, Number
-    if (!e.target.files) {
-      setFormData((prevState) => ({
-        ...prevState,
-        [e.target.id]: toggleFlag ?? e.target.value,
-      }));
+    setFormData((prevState) => ({
+      ...prevState,
+      [e.target.id]: toggleFlag ?? e.target.value,
+    }));
+  };
+
+  const handleChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const fileList = e.target.files;
+    if (!fileList) return;
+
+    setLoading(true);
+
+    const urls = await Promise.all(
+      Array.from(fileList).map((image) => storeImage(image))
+    ).catch(() => {
+      console.error("Error uploading images");
+      setLoading(false);
+      return;
+    });
+
+    if (urls) {
+      setUploadedImages((prevState) => {
+        return [...prevState, ...urls];
+      });
     }
+    setLoading(false);
+  };
+
+  const handleUpload = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    inputRef.current?.click();
+  };
+
+  const handleDeleteImage = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+
+    setLoading(true);
+
+    const targetUrl = e.currentTarget.dataset.url;
+    const targetImageRef = ref(storage, targetUrl);
+
+    deleteObject(targetImageRef)
+      .then(() => {
+        setUploadedImages((prevState) =>
+          prevState.filter((url) => url !== targetUrl)
+        );
+        console.log("File deleted successfully");
+        setLoading(false);
+      })
+      .catch((error) => {
+        console.error("Uh-oh, an error occurred!");
+        setLoading(false);
+      });
   };
 
   if (loading) {
@@ -209,12 +243,23 @@ export const EditListing = () => {
   }
 
   return (
-    <ListingForm
-      ActionText="Edit"
-      formData={formData}
-      onMutate={onMutate}
-      onSubmit={onSubmit}
-      geolocationEnabled={geolocationEnabled}
-    />
+    <div className="profile">
+      <header>
+        <p className="pageHeader">Edit Listing</p>
+      </header>
+      <main>
+        <ListingForm
+          formData={formData}
+          onMutate={onMutate}
+          onSubmit={onSubmit}
+          handleChange={handleChange}
+          handleUpload={handleUpload}
+          handleDeleteImage={handleDeleteImage}
+          uploadedImages={uploadedImages}
+          inputRef={inputRef}
+          geolocationEnabled={geolocationEnabled}
+        />
+      </main>
+    </div>
   );
 };

--- a/src/type.ts
+++ b/src/type.ts
@@ -16,7 +16,7 @@ export type ListingsItemDataType = {
     lat: number;
     lng: number;
   };
-  imgUrls: FileList;
+  imgUrls: string[];
   timestamp: FieldValue;
 };
 
@@ -32,20 +32,13 @@ export type UsersType = {
   timestamp: string;
 };
 
-export type FormDataType = {
-  type: string;
-  name: string;
-  bedrooms: number;
-  bathrooms: number;
-  parking: boolean;
-  furnished: boolean;
+export type FormDataType = Omit<
+  ListingsItemDataType,
+  "geolocation" | "imgUrls" | "timestamp" | "discountedPrice" | "location"
+> & {
   address?: string;
-  location?: string;
-  offer: boolean;
-  regularPrice: number;
-  discountedPrice?: number;
-  images?: FileList;
-  latitude: number;
-  longitude: number;
-  userRef: string;
+  latitude: ListingsItemDataType["geolocation"]["lat"];
+  longitude: ListingsItemDataType["geolocation"]["lng"];
+  discountedPrice?: ListingsItemDataType["discountedPrice"];
+  location?: ListingsItemDataType["location"];
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -121,7 +121,7 @@ export const storeImage = async (image: File): Promise<string> => {
       (snapshot) => {
         const progress =
           (snapshot.bytesTransferred / snapshot.totalBytes) * 100;
-        console.log("Upload is " + progress + "% done");
+        console.log(`${image.name}: Upload is ${progress}% done`);
         switch (snapshot.state) {
           case "paused":
             console.log("Upload is paused");
@@ -135,8 +135,8 @@ export const storeImage = async (image: File): Promise<string> => {
         reject(error);
       },
       () => {
-        getDownloadURL(uploadTask.snapshot.ref).then((downloadURL) => {
-          resolve(downloadURL);
+        getDownloadURL(uploadTask.snapshot.ref).then((downloadUrl) => {
+          resolve(downloadUrl);
         });
       }
     );


### PR DESCRIPTION
Fix https://github.com/kkata/house-marketplace/issues/7

現状：画像選択→データ送信と同時にアップロード
変更後：画像アップロード後、データ送信

画像選択でプレビュー表示にしようとしたけど、とりあえずこれで。
ただ、選択＝アップロードなので、別途プレビューは必要。
この手のUIコンポーネントはいろいろある。導入してもいいかもしれない。
